### PR TITLE
J8+ v1.0.0

### DIFF
--- a/changelogs/1.0.0.md
+++ b/changelogs/1.0.0.md
@@ -1,0 +1,8 @@
+## [v1.0.0](https://github.com/Kevin-Lee/j8plus/issues?q=is%3Aissue+milestone%3A%22milestone3%22+is%3Aclosed) - 2020-11-09
+
+### Done
+* Change `toString` to show `Just` and `Nothing` are `Maybe` (#115)
+* Change the `Maybe.just` method to `Maybe.maybe` (#116)
+
+### Fixed
+* Fix `Maybe.toString()` to handle nested `Maybe`s properly (#119)

--- a/project/ProjectInfo.scala
+++ b/project/ProjectInfo.scala
@@ -1,7 +1,7 @@
 import sbt.{Developer, ScmInfo, url}
 
 object ProjectInfo {
-  val ProjectVersion: String = "0.4.0"
+  val ProjectVersion: String = "1.0.0"
 
   val projectDevelopers: List[Developer] = List(
     Developer(


### PR DESCRIPTION
# J8+ v1.0.0
## [v1.0.0](https://github.com/Kevin-Lee/j8plus/issues?q=is%3Aissue+milestone%3A%22milestone3%22+is%3Aclosed) - 2020-11-09

### Done
* Change `toString` to show `Just` and `Nothing` are `Maybe` (#115)
* Change the `Maybe.just` method to `Maybe.maybe` (#116)

### Fixed
* Fix `Maybe.toString()` to handle nested `Maybe`s properly (#119)
