### PR TITLE
j8plus v1.1.0

### DIFF
--- a/changelogs/1.1.0.md
+++ b/changelogs/1.1.0.md
@@ -1,0 +1,8 @@
+## [v1.1.0](https://github.com/Kevin-Lee/j8plus/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone5) - 2021-01-01
+
+## Done
+* Add `Either.getOrElse` (#167)
+* Add `Either.getLeftOrElse` (#168)
+* Add `Either.forEachLeft` (#170)
+* Publish to `s01.oss.sonatype.org` (the new Maven central) (#182)
+* Set up Codecov - GitHub Actions (#185)


### PR DESCRIPTION
# j8plus v1.1.0
## [v1.1.0](https://github.com/Kevin-Lee/j8plus/issues?q=is%3Aissue+is%3Aclosed+-label%3Ainvalid+milestone%3Amilestone5) - 2021-01-01

## Done
* Add `Either.getOrElse` (#167)
* Add `Either.getLeftOrElse` (#168)
* Add `Either.forEachLeft` (#170)
* Publish to `s01.oss.sonatype.org` (the new Maven central) (#182)
* Set up Codecov - GitHub Actions (#185)
